### PR TITLE
feat: Implement Notifications page with filtering and API integration

### DIFF
--- a/src/components/notifications/notifications.jsx
+++ b/src/components/notifications/notifications.jsx
@@ -1,307 +1,145 @@
 import { useState } from "react";
-import { 
-  Bell, 
-  AlertTriangle, 
-  Calendar, 
-  Target, 
-  TrendingUp, 
-  CreditCard, 
-  PiggyBank,
-  CheckCircle,
-  Clock,
-  X
-} from "lucide-react";
+import { Activity, AlertTriangle, Bell, CircleX, Clock, X } from "lucide-react";
+import { Skeleton } from "../ui/skeleton";
 
+// Dummy reminders for now
 const mockNotifications = [
   {
-    id: '1',
-    type: 'alert',
-    title: 'Budget Alert',
-    message: "You've spent 85% of your monthly food budget",
-    time: '2 minutes ago',
-    isRead: false,
-    icon: AlertTriangle,
-    category: 'Budget'
+    id: "68e17ae8f59fc08c252c0c32",
+    title: "Budget: Social Events reached 100%",
+    description: "Your budget for Entertainment has been fully used.",
+    dueDate: "2025-10-04T19:52:08.905Z",
+    type: "fullLimit",
   },
   {
-    id: '2',
-    type: 'reminder',
-    title: 'Bill Reminder',
-    message: 'Electricity bill payment due tomorrow ($89.50)',
-    time: '1 hour ago',
-    isRead: false,
-    icon: Calendar,
-    category: 'Bills'
+    id: "68e17ae8f59fc08c252c0c2f",
+    title: "Budget: Social Events at 90%",
+    description: "Your budget for Entertainment has reached 90% of its limit.",
+    dueDate: "2025-10-03T19:52:08.433Z",
+    type: "closeLimit",
   },
   {
-    id: '3',
-    type: 'achievement',
-    title: 'Savings Goal Reached!',
-    message: "Congratulations! You've reached your vacation savings goal",
-    time: '3 hours ago',
-    isRead: true,
-    icon: Target,
-    category: 'Goals'
+    id: "68e159776b0f429437f263e2",
+    title: "No transactions logged",
+    description: "Hey, you haven't logged any transactions in 5 days. Add one today to keep your finances on track!",
+    dueDate: "2025-10-01T17:29:27.163Z",
+    type: "noTransactions",
   },
   {
-    id: '4',
-    type: 'info',
-    title: 'Weekly Report Ready',
-    message: 'Your spending decreased by 12% this week',
-    time: '1 day ago',
-    isRead: true,
-    icon: TrendingUp,
-    category: 'Reports'
+    id: "68e14ce7f57fe452937589b6",
+    title: "Budget: Social Events at 50%",
+    description: "Your budget for Entertainment has reached 50% of its limit.",
+    dueDate: "2025-10-02T16:35:51.166Z",
+    type: "halfLimit",
   },
-  {
-    id: '5',
-    type: 'reminder',
-    title: 'Credit Card Payment',
-    message: 'Card ending in 4567 payment due in 3 days ($432.18)',
-    time: '2 days ago',
-    isRead: false,
-    icon: CreditCard,
-    category: 'Bills'
-  },
-  {
-    id: '6',
-    type: 'achievement',
-    title: 'Spending Streak',
-    message: "You've stayed under budget for 7 consecutive days!",
-    time: '3 days ago',
-    isRead: true,
-    icon: PiggyBank,
-    category: 'Achievements'
-  }
 ];
 
-const Notifications = () => {
+const Notifications = ({ isLoading }) => {
   const [notifications, setNotifications] = useState(mockNotifications);
-  const [filter, setFilter] = useState('all');
-
-  const markAsRead = (id) => {
-    setNotifications(prev =>
-      prev.map(notification =>
-        notification.id === id ? { ...notification, isRead: true } : notification
-      )
-    );
-  };
-
-  const markAllAsRead = () => {
-    setNotifications(prev => prev.map(notification => ({ ...notification, isRead: true })));
-  };
 
   const deleteNotification = (id) => {
-    setNotifications(prev => prev.filter(notification => notification.id !== id));
+    setNotifications((prev) => prev.filter((n) => n.id !== id));
   };
 
-  const filteredNotifications =
-    filter === 'unread' ? notifications.filter(n => !n.isRead) : notifications;
-
-  const unreadCount = notifications.filter(n => !n.isRead).length;
-
-  const getNotificationStyles = (type) => {
-    const baseStyles =
-      "relative overflow-hidden rounded-xl border bg-white shadow transition-all duration-300 hover:scale-[1.01] hover:shadow-lg";
-
+  const getIcon = (type) => {
     switch (type) {
-      case 'alert':
-        return `${baseStyles} border-l-4 border-yellow-500 bg-yellow-50`;
-      case 'reminder':
-        return `${baseStyles} border-l-4 border-blue-500 bg-blue-50`;
-      case 'achievement':
-        return `${baseStyles} border-l-4 border-green-500 bg-green-50`;
-      case 'info':
-        return `${baseStyles} border-l-4 border-indigo-500 bg-indigo-50`;
+      case "noTransactions":
+        return <Activity className="h-5 w-5" />;
+      case "halfLimit":
+      case "closeLimit":
+      case "fullLimit":
+        return <AlertTriangle className="h-5 w-5" />;
       default:
-        return baseStyles;
+        return <Bell className="h-5 w-5" />;
     }
   };
 
-  const getIconColor = (type) => {
+  const getAccent = (type) => {
     switch (type) {
-      case 'alert':
-        return 'text-yellow-600';
-      case 'reminder':
-        return 'text-blue-600';
-      case 'achievement':
-        return 'text-green-600';
-      case 'info':
-        return 'text-indigo-600';
+      case "noTransactions":
+        return "bg-green-50 text-primary";
+      case "halfLimit":
+        return "bg-yellow-50 text-yellow-500";
+      case "closeLimit":
+        return "bg-orange-50 text-orange-600";
+      case "fullLimit":
+        return "bg-red-50 text-red-600";
       default:
-        return 'text-gray-500';
+        return "bg-indigo-50 text-indigo-600";
     }
   };
+
+  const getBorder = (type) => {
+    switch (type) {
+      case "noTransactions":
+        return "border-l-6 border-green-500";
+      case "halfLimit":
+        return "border-l-6 border-yellow-400";
+      case "closeLimit":
+        return "border-l-6 border-orange-500";
+      case "fullLimit":
+        return "border-l-6 border-red-500";
+      default:
+        return "border-l-6 border-indigo-500";
+    }
+  };
+
+  const formatDueDate = (dateStr) => {
+    const d = new Date(dateStr);
+    return d.toLocaleString("en-US", {
+      day: "2-digit",
+      month: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  };
+
+  if (isLoading) {
+    return (
+      <div className="space-y-4">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div key={i} className="rounded-xl border bg-white shadow p-6 flex items-start gap-3">
+            <Skeleton className="h-10 w-10 rounded-full" />
+            <div className="flex-1 space-y-3">
+              <Skeleton className="h-4 w-3/4" />
+              <Skeleton className="h-3 w-full" />
+              <Skeleton className="h-3 w-70" />
+            </div>
+            <Skeleton className="h-4 w-4 rounded-full" />
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  if (notifications.length === 0) {
+    return (
+      <div className="p-12 text-center rounded-xl border-2 border-yellow-400 bg-white shadow">
+        <Bell className="h-12 w-12 mx-auto mb-4 text-yellow-400" />
+        <h3 className="text-lg font-medium text-gray-600 mb-2">No notifications</h3>
+        <p className="text-sm text-gray-500">You'll see all your finance related reminders here once they’re generated.</p>
+      </div>
+    );
+  }
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-gray-50 via-gray-100 to-gray-200">
-      <div className="container mx-auto px-4 py-8 max-w-4xl">
-        {/* Header */}
-        <div className="flex items-center justify-between mb-8">
-          <div className="flex items-center gap-3">
-            <div className="relative">
-              <Bell className="h-8 w-8 text-indigo-600" />
-              {unreadCount > 0 && (
-                <span className="absolute -top-2 -right-2 h-5 w-5 flex items-center justify-center rounded-full bg-yellow-500 text-white text-xs font-bold">
-                  {unreadCount}
-                </span>
-              )}
-            </div>
-            <div>
-              <h1 className="text-3xl font-bold text-gray-800">Notifications</h1>
-              <p className="text-gray-500">Stay updated with your finances</p>
+    <div className="space-y-4">
+      {notifications.map((n) => (
+        <div key={n.id} className={`relative group rounded-xl border bg-white shadow p-4 flex items-start gap-3 transition-all duration-200 hover:shadow-lg hover:scale-[1.01] ${getBorder(n.type)}`}>
+          <div className={`p-2 rounded-full ${getAccent(n.type)}`}>{getIcon(n.type)}</div>
+          <div className="flex-1">
+            <h3 className="font-semibold text-gray-800 lg:text-lg">{n.title}</h3>
+            <p className="text-gray-600 mb-2">{n.description}</p>
+            <div className="flex items-center gap-2 text-gray-500 font-medium">
+              <Clock className="h-4 w-4" />
+              {formatDueDate(n.dueDate)}
             </div>
           </div>
-
-          {unreadCount > 0 && (
-            <button
-              onClick={markAllAsRead}
-              className="flex items-center gap-2 px-3 py-2 border rounded-lg text-sm font-medium text-gray-600 hover:bg-indigo-600 hover:text-white transition"
-            >
-              <CheckCircle className="h-4 w-4" />
-              Mark all as read
-            </button>
-          )}
-        </div>
-
-        {/* Filter Buttons */}
-        <div className="flex gap-2 mb-6">
-          <button
-            onClick={() => setFilter('all')}
-            className={`px-3 py-1 rounded-md text-sm font-medium ${
-              filter === 'all'
-                ? 'bg-indigo-600 text-white'
-                : 'border border-gray-300 text-gray-600 hover:bg-gray-100'
-            }`}
-          >
-            All ({notifications.length})
-          </button>
-          <button
-            onClick={() => setFilter('unread')}
-            className={`px-3 py-1 rounded-md text-sm font-medium ${
-              filter === 'unread'
-                ? 'bg-indigo-600 text-white'
-                : 'border border-gray-300 text-gray-600 hover:bg-gray-100'
-            }`}
-          >
-            Unread ({unreadCount})
+          <button onClick={() => deleteNotification(n.id)} className="absolute top-2 right-2 group-hover:opacity-100 transition-opacity duration-200 text-red-500 hover:text-red-700" title="Delete notification">
+            <CircleX className="h-5 w-5 md:h-6 md:w-6" />
           </button>
         </div>
-
-        {/* Notifications List */}
-        <div className="space-y-4">
-          {filteredNotifications.length === 0 ? (
-            <div className="p-12 text-center rounded-xl border bg-white shadow">
-              <Bell className="h-12 w-12 mx-auto mb-4 text-gray-300" />
-              <h3 className="text-lg font-medium text-gray-600 mb-2">
-                {filter === 'unread' ? 'No unread notifications' : 'No notifications'}
-              </h3>
-              <p className="text-sm text-gray-500">
-                {filter === 'unread'
-                  ? 'All caught up! Check back later for updates.'
-                  : "You'll see your expense notifications here."}
-              </p>
-            </div>
-          ) : (
-            filteredNotifications.map((notification) => {
-              const IconComponent = notification.icon;
-              return (
-                <div
-                  key={notification.id}
-                  className={getNotificationStyles(notification.type)}
-                >
-                  <div className="p-4">
-                    <div className="flex items-start justify-between">
-                      <div className="flex items-start gap-3 flex-1">
-                        <div
-                          className={`p-2 rounded-full bg-white shadow ${getIconColor(
-                            notification.type
-                          )}`}
-                        >
-                          <IconComponent className="h-5 w-5" />
-                        </div>
-
-                        <div className="flex-1 min-w-0">
-                          <div className="flex items-center gap-2 mb-1">
-                            <h3
-                              className={`font-semibold text-sm ${
-                                ['achievement', 'alert', 'reminder'].includes(notification.type)
-                                 ? 'text-green-700 italic'
-                                  : 'text-gray-800'
-                                   }`}
->
-                              {notification.title}
-                            </h3>
-                            {!notification.isRead && (
-                              <div className="w-2 h-2 rounded-full bg-indigo-600 animate-pulse"></div>
-                            )}
-                          </div>
-
-                          <p className="text-sm text-gray-600 mb-2 leading-relaxed">
-                            {notification.message}
-                          </p>
-
-                          <div className="flex items-center gap-3 text-xs text-gray-500">
-                            <div className="flex items-center gap-1">
-                              <Clock className="h-3 w-3" />
-                              {notification.time}
-                            </div>
-                            <span className="px-2 py-0.5 rounded-full bg-gray-200 text-gray-700 text-xs">
-                              {notification.category}
-                            </span>
-                          </div>
-                        </div>
-                      </div>
-
-                      <div className="flex items-center gap-1 ml-2">
-                        {!notification.isRead && (
-                          <button
-                            onClick={() => markAsRead(notification.id)}
-                            className="h-8 w-8 flex items-center justify-center rounded-full hover:bg-indigo-100 text-indigo-600"
-                          >
-                            <CheckCircle className="h-4 w-4" />
-                          </button>
-                        )}
-                        <button
-                          onClick={() => deleteNotification(notification.id)}
-                          className="h-8 w-8 flex items-center justify-center rounded-full hover:bg-red-100 text-red-600"
-                        >
-                          <X className="h-4 w-4" />
-                        </button>
-                      </div>
-                    </div>
-                  </div>
-
-                  {/* Gradient overlay for unread notifications */}
-                  {!notification.isRead && (
-                    <div className="absolute inset-0 bg-gradient-to-r from-indigo-50 to-transparent pointer-events-none"></div>
-                  )}
-                </div>
-              );
-            })
-          )}
-        </div>
-
-        {/* Quick Stats Footer */}
-        {notifications.length > 0 && (
-          <div className="mt-8 p-4 rounded-xl border bg-white shadow">
-            <div className="flex items-center justify-center gap-6 text-sm text-gray-600">
-              <div className="flex items-center gap-2">
-                <div className="w-3 h-3 rounded-full bg-yellow-500"></div>
-                <span>{notifications.filter(n => n.type === 'alert').length} Alerts</span>
-              </div>
-              <div className="flex items-center gap-2">
-                <div className="w-3 h-3 rounded-full bg-blue-500"></div>
-                <span>{notifications.filter(n => n.type === 'reminder').length} Reminders</span>
-              </div>
-              <div className="flex items-center gap-2">
-                <div className="w-3 h-3 rounded-full bg-green-500"></div>
-                <span>{notifications.filter(n => n.type === 'achievement').length} Achievements</span>
-              </div>
-            </div>
-          </div>
-        )}
-      </div>
+      ))}
     </div>
   );
 };

--- a/src/components/notifications/notifications.jsx
+++ b/src/components/notifications/notifications.jsx
@@ -1,104 +1,87 @@
-import { useState } from "react";
-import { Activity, AlertTriangle, Bell, CircleX, Clock, X } from "lucide-react";
-import { Skeleton } from "../ui/skeleton";
+import { useNotifications, useDeleteNotification } from "@/hooks/useNotifications";
+import { useUIStore } from "@/stores/uiStore";
+import { Bell, Clock, CircleX, AlertTriangle, Activity } from "lucide-react";
+import { Skeleton } from "@/components/ui/skeleton";
 
-// Dummy reminders for now
-const mockNotifications = [
-  {
-    id: "68e17ae8f59fc08c252c0c32",
-    title: "Budget: Social Events reached 100%",
-    description: "Your budget for Entertainment has been fully used.",
-    dueDate: "2025-10-04T19:52:08.905Z",
-    type: "fullLimit",
-  },
-  {
-    id: "68e17ae8f59fc08c252c0c2f",
-    title: "Budget: Social Events at 90%",
-    description: "Your budget for Entertainment has reached 90% of its limit.",
-    dueDate: "2025-10-03T19:52:08.433Z",
-    type: "closeLimit",
-  },
-  {
-    id: "68e159776b0f429437f263e2",
-    title: "No transactions logged",
-    description: "Hey, you haven't logged any transactions in 5 days. Add one today to keep your finances on track!",
-    dueDate: "2025-10-01T17:29:27.163Z",
-    type: "noTransactions",
-  },
-  {
-    id: "68e14ce7f57fe452937589b6",
-    title: "Budget: Social Events at 50%",
-    description: "Your budget for Entertainment has reached 50% of its limit.",
-    dueDate: "2025-10-02T16:35:51.166Z",
-    type: "halfLimit",
-  },
-];
+// --- Helpers ---
+const getIcon = (type) => {
+  switch (type) {
+    case "noTransactions":
+      return <Activity className="h-5 w-5" />;
+    case "halfLimit":
+    case "closeLimit":
+    case "fullLimit":
+      return <AlertTriangle className="h-5 w-5" />;
+    default:
+      return <Bell className="h-5 w-5" />;
+  }
+};
 
-const Notifications = ({ isLoading }) => {
-  const [notifications, setNotifications] = useState(mockNotifications);
+const getAccent = (type) => {
+  switch (type) {
+    case "noTransactions":
+      return "bg-green-50 text-primary";
+    case "halfLimit":
+      return "bg-yellow-50 text-yellow-500";
+    case "closeLimit":
+      return "bg-orange-50 text-orange-600";
+    case "fullLimit":
+      return "bg-red-50 text-red-600";
+    default:
+      return "bg-indigo-50 text-indigo-600";
+  }
+};
 
-  const deleteNotification = (id) => {
-    setNotifications((prev) => prev.filter((n) => n.id !== id));
-  };
+const getBorder = (type) => {
+  switch (type) {
+    case "noTransactions":
+      return "border-l-6 border-green-500";
+    case "halfLimit":
+      return "border-l-6 border-yellow-400";
+    case "closeLimit":
+      return "border-l-6 border-orange-500";
+    case "fullLimit":
+      return "border-l-6 border-red-500";
+    default:
+      return "border-l-6 border-indigo-500";
+  }
+};
 
-  const getIcon = (type) => {
-    switch (type) {
-      case "noTransactions":
-        return <Activity className="h-5 w-5" />;
-      case "halfLimit":
-      case "closeLimit":
-      case "fullLimit":
-        return <AlertTriangle className="h-5 w-5" />;
-      default:
-        return <Bell className="h-5 w-5" />;
-    }
-  };
+const formatDueDate = (dateStr) => {
+  const d = new Date(dateStr);
+  return d.toLocaleString("en-US", {
+    day: "2-digit",
+    month: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+};
 
-  const getAccent = (type) => {
-    switch (type) {
-      case "noTransactions":
-        return "bg-green-50 text-primary";
-      case "halfLimit":
-        return "bg-yellow-50 text-yellow-500";
-      case "closeLimit":
-        return "bg-orange-50 text-orange-600";
-      case "fullLimit":
-        return "bg-red-50 text-red-600";
-      default:
-        return "bg-indigo-50 text-indigo-600";
-    }
-  };
+// --- Component ---
+const Notifications = () => {
+  const { selectedMonth } = useUIStore();
 
-  const getBorder = (type) => {
-    switch (type) {
-      case "noTransactions":
-        return "border-l-6 border-green-500";
-      case "halfLimit":
-        return "border-l-6 border-yellow-400";
-      case "closeLimit":
-        return "border-l-6 border-orange-500";
-      case "fullLimit":
-        return "border-l-6 border-red-500";
-      default:
-        return "border-l-6 border-indigo-500";
-    }
-  };
+  // Extract month/year from Zustand store
+  const month = selectedMonth?.getMonth();
+  const year = selectedMonth?.getFullYear();
 
-  const formatDueDate = (dateStr) => {
-    const d = new Date(dateStr);
-    return d.toLocaleString("en-US", {
-      day: "2-digit",
-      month: "2-digit",
-      hour: "2-digit",
-      minute: "2-digit",
-    });
-  };
+  const { data: notifications, isLoading, error } = useNotifications();
+  const { mutate: deleteNotification } = useDeleteNotification();
+
+  // --- Frontend filtering ---
+  const filteredNotifications = notifications?.filter((n) => {
+    const d = new Date(n.dueDate);
+    return d.getMonth() === month && d.getFullYear() === year;
+  });
 
   if (isLoading) {
     return (
       <div className="space-y-4">
         {Array.from({ length: 3 }).map((_, i) => (
-          <div key={i} className="rounded-xl border bg-white shadow p-6 flex items-start gap-3">
+          <div
+            key={i}
+            className="rounded-xl border bg-white shadow p-6 flex items-start gap-3"
+          >
             <Skeleton className="h-10 w-10 rounded-full" />
             <div className="flex-1 space-y-3">
               <Skeleton className="h-4 w-3/4" />
@@ -112,21 +95,34 @@ const Notifications = ({ isLoading }) => {
     );
   }
 
-  if (notifications.length === 0) {
+  if (error) {
+    return <p className="text-red-500">Failed to load notifications</p>;
+  }
+
+  if (!filteredNotifications || filteredNotifications.length === 0) {
     return (
       <div className="p-12 text-center rounded-xl border-2 border-yellow-400 bg-white shadow">
         <Bell className="h-12 w-12 mx-auto mb-4 text-yellow-400" />
         <h3 className="text-lg font-medium text-gray-600 mb-2">No notifications</h3>
-        <p className="text-sm text-gray-500">You'll see all your finance related reminders here once they’re generated.</p>
+        <p className="text-sm text-gray-500">
+          You'll see all your finance related notifications here once they’re generated.
+        </p>
       </div>
     );
   }
 
   return (
     <div className="space-y-4">
-      {notifications.map((n) => (
-        <div key={n.id} className={`relative group rounded-xl border bg-white shadow p-4 flex items-start gap-3 transition-all duration-200 hover:shadow-lg hover:scale-[1.01] ${getBorder(n.type)}`}>
-          <div className={`p-2 rounded-full ${getAccent(n.type)}`}>{getIcon(n.type)}</div>
+      {filteredNotifications.map((n) => (
+        <div
+          key={n.id}
+          className={`relative group rounded-xl border bg-white shadow p-4 flex items-start gap-3 transition-all duration-200 hover:shadow-lg hover:scale-[1.01] ${getBorder(
+            n.type
+          )}`}
+        >
+          <div className={`p-2 rounded-full ${getAccent(n.type)}`}>
+            {getIcon(n.type)}
+          </div>
           <div className="flex-1">
             <h3 className="font-semibold text-gray-800 lg:text-lg">{n.title}</h3>
             <p className="text-gray-600 mb-2">{n.description}</p>
@@ -135,7 +131,11 @@ const Notifications = ({ isLoading }) => {
               {formatDueDate(n.dueDate)}
             </div>
           </div>
-          <button onClick={() => deleteNotification(n.id)} className="absolute top-2 right-2 group-hover:opacity-100 transition-opacity duration-200 text-red-500 hover:text-red-700" title="Delete notification">
+          <button
+            onClick={() => deleteNotification(n.id)}
+            className="absolute top-2 right-2 group-hover:opacity-100 transition-opacity duration-200 text-red-500 hover:text-red-700"
+            title="Delete notification"
+          >
             <CircleX className="h-5 w-5 md:h-6 md:w-6" />
           </button>
         </div>

--- a/src/hooks/useNotifications.js
+++ b/src/hooks/useNotifications.js
@@ -1,0 +1,25 @@
+
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useApi } from "@/api";
+
+// Fetch notifications (calls /reminders backend)
+export const useNotifications = (upcoming = false) => {
+  const { getProtectedData } = useApi();
+  return useQuery({
+    queryKey: ["notifications", { upcoming }],
+    queryFn: () => getProtectedData(`reminders?upcoming=${upcoming}`),
+  });
+};
+
+// Delete notification (calls /reminders/:id backend)
+export const useDeleteNotification = () => {
+  const { deleteProtectedData } = useApi();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id) => deleteProtectedData(`reminders/${id}`),
+    onSuccess: () => {
+      queryClient.invalidateQueries(["notifications"]);
+    },
+  });
+};

--- a/src/pages/notifications.page.jsx
+++ b/src/pages/notifications.page.jsx
@@ -1,16 +1,7 @@
 import { MonthYearPicker } from "@/components/transactions/month-year-picker.jsx";
 import Notifications from "./../components/notifications/notifications.jsx";
-import { useEffect, useState } from "react";
 
 const NotificationsPage = () => {
-  const [isLoading, setIsLoading] = useState(true);
-
-  useEffect(() => {
-    // simulate fetch delay
-    const timer = setTimeout(() => setIsLoading(false), 1500);
-    return () => clearTimeout(timer);
-  }, []);
-
   return (
     <div className="rounded-lg mx-2 md:mx-20 lg:mx-30 my-2 py-4 lg:px-8">
       <div className="mx-2 lg:mx-20">
@@ -22,7 +13,7 @@ const NotificationsPage = () => {
         <p className="text-center mb-2 lg:text-lg">These are your Notifications overview</p>
 
         {/* Notifications list */}
-        <Notifications isLoading={isLoading} />
+        <Notifications/>
       </div>
     </div>
   );

--- a/src/pages/notifications.page.jsx
+++ b/src/pages/notifications.page.jsx
@@ -1,15 +1,29 @@
+import { MonthYearPicker } from "@/components/transactions/month-year-picker.jsx";
 import Notifications from "./../components/notifications/notifications.jsx";
-
+import { useEffect, useState } from "react";
 
 const NotificationsPage = () => {
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    // simulate fetch delay
+    const timer = setTimeout(() => setIsLoading(false), 1500);
+    return () => clearTimeout(timer);
+  }, []);
+
   return (
     <div className="rounded-lg mx-2 md:mx-20 lg:mx-30 my-2 py-4 lg:px-8">
-      {/* Header */}
-      <div className="px-6 py-4 text-center">
-        <h1 className="text-2xl font-bold text-gray-800">Notifications</h1>
-        <p className="text-gray-600 text-lg mt-1">These are your Notifications overview</p>
+      <div className="mx-2 lg:mx-20">
+        {/* Header */}
+        <div className="mb-3 lg:mb-1 flex flex-wrap items-center justify-between gap-4">
+          <h1 className="text-2xl font-bold text-gray-800">Notifications</h1>
+          <MonthYearPicker />
+        </div>
+        <p className="text-center mb-2 lg:text-lg">These are your Notifications overview</p>
+
+        {/* Notifications list */}
+        <Notifications isLoading={isLoading} />
       </div>
-      <Notifications />
     </div>
   );
 };


### PR DESCRIPTION
This pull request introduces the complete frontend implementation for the **Notifications page**. It establishes the core UI, filtering capabilities, & full integration with the backend API for fetching & managing reminders. The components have been designed with improved future scalability, simplifying client-side logic to rely on the backend's defined notification types & statuses.

### **Key Changes**

* **API Integration & State Management:**
    * [x] Set up **React Query hooks** for fetching & deleting notifications/reminders from the backend API.
    * [x] Implemented **Skeleton loading states** in the `Notifications` component for a smoother user experience during data fetching.

* **UI & Filtering:**
    * [x] Updated the `NotificationsPage` component with a header layout.
    * [x] Integrated a **`MonthYearPicker`** in the header, allowing users to filter notifications by month.
    * [x] Implemented a new design for notification cards that displays various reminder types (e.g., `halfLimit`, `noTransactions`) with corresponding **icons & accent colors**.

* **Functionality & Scalability Refactor:**
    * [x] Added **delete functionality** for individual notifications.
    * [x] Simplified the component logic to remove complex client-side read/unread state management, shifting that responsibility to the backend.
    * [x] Updated the **empty state UI** to be cleaner & more informative when no notifications are present.